### PR TITLE
[PR#60] - fix add product decription validation

### DIFF
--- a/app/components/ui/Inputs/Validation/ProductInput.tsx
+++ b/app/components/ui/Inputs/Validation/ProductInput.tsx
@@ -58,7 +58,7 @@ export function ProductInput({
       requiredMessage: "This field is required",
       pattern: {
         value: /^[-()#%/"'`~\[\]a-zA-Z0-9\n ]{0,600}$/,
-        message: "Enter description 0-600 symbols",
+        message: "Enter description 0-600 symbols. No !@$^*_&=\\ allowed",
       },
     },
     price: {

--- a/app/components/ui/Inputs/Validation/ProductInput.tsx
+++ b/app/components/ui/Inputs/Validation/ProductInput.tsx
@@ -57,7 +57,7 @@ export function ProductInput({
     subTitle: {
       requiredMessage: "This field is required",
       pattern: {
-        value: /^[-()#%/a-zA-Z0-9\n ]{0,600}$/,
+        value: /^[-()#%/"'`~\[\]a-zA-Z0-9\n ]{0,600}$/,
         message: "Enter description 0-600 symbols",
       },
     },


### PR DESCRIPTION
# Changes
### 1. Specific error messagee
Now user get much specific error message when adding product description

2. Validation improved
Added this symbols for allowed in desctiption
```
value: /^[-()#%/"'`~\[\]a-zA-Z0-9\n ]{0,600}$/,
```


# Result
![image](https://github.com/nicitaacom/23_store/assets/39565703/2eaf905c-8d08-4df4-9aac-1f8c90837922)


**Github task** - https://github.com/users/nicitaacom/projects/5/views/1?pane=issue&itemId=43923210&sortedBy%5Bdirection%5D=desc&sortedBy%5BcolumnId%5D=59471618
This task done - delete this branch and move task to 'Done'