### PR TITLE
[FR#81] - callback redirect in production

### DIFF
--- a/app/(auth)/AuthModal/AuthModal.tsx
+++ b/app/(auth)/AuthModal/AuthModal.tsx
@@ -182,7 +182,7 @@ export function AuthModal({ label }: AdminModalProps) {
                 onClick={async () =>
                   await supabaseClient.auth.signInWithOAuth({
                     provider: "google",
-                    options: { redirectTo: `${getURL()}/auth/callback/oauth?provider=google` },
+                    options: { redirectTo: `${getURL()}auth/callback/oauth?provider=google` },
                   })
                 }>
                 continue with google?
@@ -264,6 +264,9 @@ export function AuthModal({ label }: AdminModalProps) {
       const { error: resendError } = await supabaseClient.auth.resend({
         type: "signup",
         email: email,
+        options: {
+          emailRedirectTo: `${getURL()}auth/callback/credentials`,
+        },
       })
       if (resendError) throw resendError
 
@@ -307,7 +310,7 @@ export function AuthModal({ label }: AdminModalProps) {
   async function recoverPassword(email: string) {
     try {
       const { error } = await supabaseClient.auth.resetPasswordForEmail(email, {
-        redirectTo: `${getURL()}/auth/callback/recover`,
+        redirectTo: `${getURL()}auth/callback/recover`,
       })
       if (error) throw error
 


### PR DESCRIPTION
Fix for this

To reproduce:
1. click 'recover password' button in production
2. click on the button in verication email

![2023-11-18_12-56](https://github.com/nicitaacom/23_store/assets/39565703/3082ea87-0270-4746-94bf-cc966653d6cd)


expected to see modal resetPassword